### PR TITLE
Remove NAME variable from app paths

### DIFF
--- a/Creative Do/ZXPInstaller.install.recipe
+++ b/Creative Do/ZXPInstaller.install.recipe
@@ -30,7 +30,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>ZXPInstaller.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/Creative Do/ZXPInstaller.munki.recipe
+++ b/Creative Do/ZXPInstaller.munki.recipe
@@ -42,7 +42,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%pathname%/%NAME%.app/Contents/Info.plist</string>
+				<string>%pathname%/ZXPInstaller.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleVersion</string>
 			</dict>

--- a/Creative Do/ZXPInstaller.pkg.recipe
+++ b/Creative Do/ZXPInstaller.pkg.recipe
@@ -25,7 +25,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%pathname%/%NAME%.app/Contents/Info.plist</string>
+				<string>%pathname%/ZXPInstaller.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleVersion</string>
 			</dict>
@@ -50,9 +50,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/ZXPInstaller.app</string>
 				<key>source_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/ZXPInstaller.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>

--- a/Flixel Photos Inc./CinemagraphPro.download.recipe
+++ b/Flixel Photos Inc./CinemagraphPro.download.recipe
@@ -58,7 +58,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Cinemagraph Pro.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.flixel.mac.cinemagraphpro" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "8D2X524S6C")</string>
 			</dict>

--- a/Flixel Photos Inc./CinemagraphPro.install.recipe
+++ b/Flixel Photos Inc./CinemagraphPro.install.recipe
@@ -41,7 +41,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Cinemagraph Pro.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/Intuit Inc./QuickBooks2016.download.recipe
+++ b/Intuit Inc./QuickBooks2016.download.recipe
@@ -60,7 +60,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/QuickBooks.app</string>
 				<key>requirement</key>
 				<string>identifier "com.intuit.QuickBooks2016" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = G4SSPX3CBL</string>
 			</dict>
@@ -73,7 +73,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>source</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/QuickBooks.app</string>
 				<key>target</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME% 2016.app</string>
 			</dict>

--- a/Notion Labs, Inc./Notion.pkg.recipe
+++ b/Notion Labs, Inc./Notion.pkg.recipe
@@ -35,7 +35,7 @@
             <key>Arguments</key>
             <dict>
                 <key>destination_path</key>
-                <string>%pkgroot%/Applications/%NAME%.app</string>
+                <string>%pkgroot%/Applications/Notion.app</string>
                 <key>source_path</key>
                 <string>%RECIPE_CACHE_DIR%/downloads/%NAME%.dmg/Notion.app</string>
             </dict>

--- a/Spatial Media Metadata Injector/SpatialMediaMetadataInjector.install.recipe
+++ b/Spatial Media Metadata Injector/SpatialMediaMetadataInjector.install.recipe
@@ -54,7 +54,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Spatial Media Metadata Injector.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/Spatial Media Metadata Injector/SpatialMediaMetadataInjector.pkg.recipe
+++ b/Spatial Media Metadata Injector/SpatialMediaMetadataInjector.pkg.recipe
@@ -38,7 +38,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Spatial Media Metadata Injector.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>


### PR DESCRIPTION
Because variables can be overridden, it's a good idea to make sure that the recipe will still work even if a non-default variables used. One issue that would prevent recipes from running is using a `NAME` variable in paths that should be hard-coded (e.g. `/Applications/Foo.app`).

This PR removes the `NAME` variable from all file paths and replaces it with the actual app name, which should make the recipe more resilient for overrides.