### PR TITLE
Set permissions for Notion.pkg.recipe

### DIFF
--- a/Notion Labs, Inc./Notion.pkg.recipe
+++ b/Notion Labs, Inc./Notion.pkg.recipe
@@ -65,6 +65,8 @@
                             <string>Applications</string>
                             <key>user</key>
                             <string>root</string>
+                            <key>mode</key>
+                            <string>0775</string>
                         </dict>
                     </array>
                     <key>id</key>


### PR DESCRIPTION
Updated the PkgCreator permissions to 0775 for compatibility with Notion 2.0.1.

Testing with Notion 2.0.1 and macOS 10.15.1 launching the application would result in a "Invalid Install" message. This PR fixes the permissions issue.

![image](https://user-images.githubusercontent.com/38663831/70110133-f8a96300-161b-11ea-9cf3-af9185b9625f.png)
> Hello, your Notion application is not installed properly. You need to move your Notion app into your Applications folder. 
> https://www.notion.so/How-to-fix-Notion-Mac-app-installation-b2be23041a0b4b948aa675184abc9165
