### PR TITLE
Use pkg install for Notion.munki.recipe & updated permissions

### DIFF
--- a/Notion Labs, Inc./Notion.download.recipe
+++ b/Notion Labs, Inc./Notion.download.recipe
@@ -47,16 +47,7 @@
                 <key>requirement</key>
                 <string>identifier "notion.id" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = LBQJ96FQ8D</string>
             </dict>
-         </dict>
-            <dict>
-            <key>Processor</key>
-            <string>DeprecationWarning</string>
-            <key>Arguments</key>
-            <dict>
-                <key>warning_message</key>
-                <string>The resulting munki install from the Notion pkgs now lead to an app that complains about improper installation. Pull requests welcome.  Without a solution, Notion recipes will be retired in February 2021.</string>
-            </dict>
-       	</dict>
+        </dict>
     </array>
 </dict>
 </plist>

--- a/Notion Labs, Inc./Notion.install.recipe
+++ b/Notion Labs, Inc./Notion.install.recipe
@@ -37,16 +37,6 @@
 			<key>Processor</key>
 			<string>InstallFromDMG</string>
 		</dict>	
-		<dict>
-            <key>Processor</key>
-            <string>DeprecationWarning</string>
-            <key>Arguments</key>
-            <dict>
-                <key>warning_message</key>
-                <string>The resulting munki install from the Notion pkgs now lead to an app that complains about improper installation. Pull requests welcome.  Without a solution, Notion recipes will be retired in February 2021.</string>
-            </dict>
-		</dict>
-		
 	</array>
 </dict>
 </plist>

--- a/Notion Labs, Inc./Notion.munki.recipe
+++ b/Notion Labs, Inc./Notion.munki.recipe
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>Comment</key>
-    <string>Created with Recipe Robot v1.0.5 (https://github.com/homebysix/recipe-robot)</string>
     <key>Description</key>
     <string>Downloads the latest version of Notion and imports it into Munki.</string>
     <key>Identifier</key>
@@ -35,33 +33,41 @@
         </dict>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.3.1</string>
+    <string>1.1</string>
     <key>ParentRecipe</key>
-	<string>com.github.swy.download.Notion</string>
+	<string>com.github.swy.pkg.Notion</string>
     <key>Process</key>
-	<array>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>pkg_path</key>
-				<string>%RECIPE_CACHE_DIR%/downloads/%NAME%.dmg</string>
-				<key>repo_subdirectory</key>
-				<string>%MUNKI_REPO_SUBDIR%</string>
-				<key>version_comparison_key</key>
-				<string>CFBundleShortVersionString</string>
-			</dict>
-			<key>Processor</key>
-			<string>MunkiImporter</string>
-		</dict>
-			<dict>
-            <key>Processor</key>
-            <string>DeprecationWarning</string>
+    <array>
+        <dict>
             <key>Arguments</key>
             <dict>
-                <key>warning_message</key>
-                <string>The resulting munki install from the Notion pkgs now lead to an app that complains about improper installation. Pull requests welcome.  Without a solution, Notion recipes will be retired in February 2021.</string>
+                <key>faux_root</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%</string>
+                <key>installs_item_paths</key>
+                <array>
+                    <string>/Applications/Notion.app</string>
+                </array>
+                <key>version_comparison_key</key>
+                <string>CFBundleShortVersionString</string>
             </dict>
-		</dict>
+            <key>Processor</key>
+            <string>MunkiInstallsItemsCreator</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>repo_subdirectory</key>
+                <string>%MUNKI_REPO_SUBDIR%</string>
+                <key>version_comparison_key</key>
+                <string>CFBundleShortVersionString</string>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiImporter</string>
+        </dict>
     </array>
 </dict>
 </plist>

--- a/Notion Labs, Inc./Notion.munki.recipe
+++ b/Notion Labs, Inc./Notion.munki.recipe
@@ -6,7 +6,7 @@
     <string>Downloads the latest version of Notion and imports it into Munki.</string>
     <key>Identifier</key>
     <string>com.github.swy.munki.Notion</string>
-      <key>Input</key>
+    <key>Input</key>
     <dict>
         <key>MUNKI_REPO_SUBDIR</key>
         <string>apps/%NAME%</string>
@@ -14,16 +14,20 @@
         <string>Notion</string>
         <key>pkginfo</key>
         <dict>
+            <key>blocking_applications</key>
+            <array>
+                <string>Notion</string>
+            </array>
             <key>catalogs</key>
             <array>
                 <string>testing</string>
             </array>
-           	<key>category</key>
-			<string>Productivity</string>
-			<key>developer</key>
-			<string>Notion Labs, Inc.</string>
+            <key>category</key>
+            <string>Productivity</string>
             <key>description</key>
             <string>A unified workspace for modern teams.</string>
+            <key>developer</key>
+            <string>Notion Labs, Inc.</string>
             <key>display_name</key>
             <string>Notion</string>
             <key>name</key>
@@ -35,35 +39,16 @@
     <key>MinimumVersion</key>
     <string>1.1</string>
     <key>ParentRecipe</key>
-	<string>com.github.swy.pkg.Notion</string>
+    <string>com.github.swy.pkg.Notion</string>
     <key>Process</key>
     <array>
         <dict>
             <key>Arguments</key>
             <dict>
-                <key>faux_root</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%</string>
-                <key>installs_item_paths</key>
-                <array>
-                    <string>/Applications/Notion.app</string>
-                </array>
-                <key>version_comparison_key</key>
-                <string>CFBundleShortVersionString</string>
-            </dict>
-            <key>Processor</key>
-            <string>MunkiInstallsItemsCreator</string>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>MunkiPkginfoMerger</string>
-        </dict>
-        <dict>
-            <key>Arguments</key>
-            <dict>
+                <key>pkg_path</key>
+                <string>%pkg_path%</string>
                 <key>repo_subdirectory</key>
                 <string>%MUNKI_REPO_SUBDIR%</string>
-                <key>version_comparison_key</key>
-                <string>CFBundleShortVersionString</string>
             </dict>
             <key>Processor</key>
             <string>MunkiImporter</string>

--- a/Notion Labs, Inc./Notion.pkg.recipe
+++ b/Notion Labs, Inc./Notion.pkg.recipe
@@ -83,15 +83,6 @@
             </dict>
             <key>Processor</key>
             <string>PkgCreator</string>
-            </dict>
-            <dict>
-            <key>Processor</key>
-            <string>DeprecationWarning</string>
-            <key>Arguments</key>
-            <dict>
-                <key>warning_message</key>
-                <string>The resulting munki install from the Notion pkgs now lead to an app that complains about improper installation. Pull requests welcome.  Without a solution, Notion recipes will be retired in February 2021.</string>
-            </dict>
         </dict>
     </array>
 </dict>

--- a/Notion Labs, Inc./Notion.pkg.recipe
+++ b/Notion Labs, Inc./Notion.pkg.recipe
@@ -60,6 +60,16 @@
                     <array>
                         <dict>
                             <key>group</key>
+                            <string>admin</string>
+                            <key>path</key>
+                            <string>Applications</string>
+                            <key>user</key>
+                            <string>root</string>
+                            <key>mode</key>
+                            <string>0775</string>
+                        </dict>
+                        <dict>
+                            <key>group</key>
                             <string>staff</string>
                             <key>path</key>
                             <string>Applications/Notion.app</string>

--- a/Notion Labs, Inc./Notion.pkg.recipe
+++ b/Notion Labs, Inc./Notion.pkg.recipe
@@ -62,7 +62,7 @@
                             <key>group</key>
                             <string>staff</string>
                             <key>path</key>
-                            <string>Applications</string>
+                            <string>Applications/Notion.app</string>
                             <key>user</key>
                             <string>root</string>
                             <key>mode</key>

--- a/Notion Labs, Inc./Notion.pkg.recipe
+++ b/Notion Labs, Inc./Notion.pkg.recipe
@@ -60,7 +60,7 @@
                     <array>
                         <dict>
                             <key>group</key>
-                            <string>admin</string>
+                            <string>staff</string>
                             <key>path</key>
                             <string>Applications</string>
                             <key>user</key>


### PR DESCRIPTION
This PR includes 3 changes:
- uses the pkg install as parent for Notion.munki.recipe
- adds permissions to Notion.app for the staff group (required for standard macOS users)
- and removes the deprecation warnings

This resolves the "Invalid Install" error message for both Munki and JSS standard macOS users.

Once merged #12 can be closed.