### PR TITLE
added post-install script to fix permissions.

### DIFF
--- a/Notion Labs, Inc./Notion.munki.recipe
+++ b/Notion Labs, Inc./Notion.munki.recipe
@@ -34,6 +34,10 @@
             <string>%NAME%</string>
             <key>unattended_install</key>
             <true/>
+            <key>postinstall_script</key>
+            <string>#!/bin/sh
+/usr/bin/chgrp -R staff /Applications/Notion.app &amp;&amp; /bin/chmod -R 775 /Applications/Notion.app
+</string>
         </dict>
     </dict>
     <key>MinimumVersion</key>


### PR DESCRIPTION
Notion wants the running user to have write access to the app bundle. This post-install script adds the `staff` group with read/write/execute permissions to the app bundle.