### PR TITLE
Brave Browser download recipe

### DIFF
--- a/BraveUniversal/BraveUniversal.download.recipe
+++ b/BraveUniversal/BraveUniversal.download.recipe
@@ -51,7 +51,7 @@
 				<key>input_plist_path</key>
 				<string>%pathname%/Brave Browser.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
-				<string>CFBundleVersion</string>
+				<string>CFBundleShortVersionString</string>
 			</dict>
 			<key>Processor</key>
 			<string>Versioner</string>


### PR DESCRIPTION
For the Brave Browser download recipe, I changed the plist_version_key to CFBundleShortVersionString to get the correct package version.