### PR TITLE
Fixed Notion download URL

### DIFF
--- a/Notion Labs, Inc./Notion.download.recipe
+++ b/Notion Labs, Inc./Notion.download.recipe
@@ -3,12 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the latest version of Notion.
-
-Set DOWNLOAD_URL with the required download url:
-x86_64: https://www.notion.so/desktop/mac/download
-arm64: https://www.notion.so/desktop/apple-silicon/download
-</string>
+    <string>Downloads the latest universal version of Notion.</string>
     <key>Identifier</key>
     <string>com.github.swy.download.Notion</string>
     <key>Input</key>
@@ -18,7 +13,7 @@ arm64: https://www.notion.so/desktop/apple-silicon/download
         <key>USER_AGENT</key>
         <string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36</string>
         <key>DOWNLOAD_URL</key>
-        <string>https://www.notion.so/desktop/mac/download</string>
+        <string>https://www.notion.so/desktop/mac-universal/download</string>
     </dict>
     <key>MinimumVersion</key>
     <string>1.0.0</string>


### PR DESCRIPTION
Notion seems to have removed the ARM-specific download URL. The previous ARM URL now throws a 404 and the AutoPKG recipe downloads the error page instead of the DMG.

Notion has added a universal binary version at https://www.notion.so/desktop/mac-universal/download. This PR updates the download URL to the universal URL and updates the description to remove references to the Intel/ARM specific URLs.

- Updated download recipe Description
- Updated download recipe DOWNLOAD_URL

I've successfully used the URL in my Munki recipe override that uses this download recipe as a parent.